### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # DS_screenSize
-Objective C solution to find out the exact model of iPhone or iPad based on actual width and heigth of the device. 
+Objective C solution to find out the exact model of iPhone or iPad based on actual width and height of the device. 
 Here is the code to use it:
 ```
     // fetch proper size of the screen for the device at hand


### PR DESCRIPTION
fixed spelling of height on the README.md
There is also other places where height is misspelled.
I am doing this as a university assignment where I am required to improve documentation in the open source community. I hope changes suggested in this commit are useful for your project.